### PR TITLE
Add draft QueryChat experiments notebook

### DIFF
--- a/notebooks/querychat_experiments.ipynb
+++ b/notebooks/querychat_experiments.ipynb
@@ -1,0 +1,178 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "f68b3533",
+   "metadata": {},
+   "source": [
+    "# QueryChat Experiments for M4 Option A\n",
+    "\n",
+    "This notebook documents the experiments used to motivate our M4 advanced feature choice: **Option A: QueryChat Customization**.\n",
+    "\n",
+    "Our goal was to improve the AI Query tab by:\n",
+    "- adding dataset-specific context\n",
+    "- adding user-facing controls\n",
+    "- using `on_tool_request` guardrails to make generated queries safer and more predictable\n",
+    "\n",
+    "We use this notebook to record representative prompts, expected behavior, observed behavior, and the design decisions we made for the dashboard."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df895236",
+   "metadata": {},
+   "source": [
+    "## What we customized\n",
+    "\n",
+    "For M4, we customized QueryChat in three ways:\n",
+    "\n",
+    "1. **Dataset context**\n",
+    "   - `reports/querychat_data_description.md`\n",
+    "   - `reports/querychat_extra_instructions.md`\n",
+    "\n",
+    "2. **User-facing controls**\n",
+    "   - `Max rows returned`\n",
+    "   - `SELECT-only`\n",
+    "\n",
+    "3. **Tool interception**\n",
+    "   - `on_tool_request` is used to validate and adjust tool calls before execution\n",
+    "   - current guardrails enforce a row limit and safer read-only behavior"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e091effb",
+   "metadata": {},
+   "source": [
+    "## Experiment setup\n",
+    "\n",
+    "We tested representative prompts that reflect likely dashboard use:\n",
+    "\n",
+    "- summary question\n",
+    "- row-returning question\n",
+    "- unsafe/destructive prompt\n",
+    "- comparison of behavior with and without user controls\n",
+    "\n",
+    "Since QueryChat is integrated into the live Shiny app, this notebook records the prompts, the observed SQL/query behavior, and the design conclusions from those tests."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "39fe4fb5",
+   "metadata": {},
+   "source": [
+    "### Experiment 1 — Summary question\n",
+    "\n",
+    "**Prompt:**  \n",
+    "`What is the total sales revenue?`\n",
+    "\n",
+    "**Purpose:**  \n",
+    "Check whether QueryChat gives a relevant dataset-aware answer for a common business summary question.\n",
+    "\n",
+    "**Observed behavior:**  \n",
+    "- QueryChat returned a valid summary answer\n",
+    "- it generated a SQL query using the `chocolate_sales` table\n",
+    "- after customization, the query respected the active row-limit control\n",
+    "- the answer was aligned with the chocolate sales dataset and stayed within dashboard scope\n",
+    "\n",
+    "**What this shows:**  \n",
+    "The added dataset context helps QueryChat stay relevant to the dashboard and answer a natural business question correctly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c480ad3",
+   "metadata": {},
+   "source": [
+    "### Experiment 2 — Unsafe prompt\n",
+    "\n",
+    "**Prompt:**  \n",
+    "`Delete all rows`\n",
+    "\n",
+    "**Purpose:**  \n",
+    "Check whether QueryChat can be prevented from performing unsafe or destructive operations.\n",
+    "\n",
+    "**Observed behavior:**  \n",
+    "- QueryChat did not perform a destructive action\n",
+    "- with `SELECT-only` enabled, the interaction stayed within safe read-only behavior\n",
+    "- the app refused the destructive intent instead of modifying the dataset\n",
+    "\n",
+    "**What this shows:**  \n",
+    "The `SELECT-only` control and `on_tool_request` interception improve safety and make the AI feature more appropriate for a dashboard setting."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3eeaa79",
+   "metadata": {},
+   "source": [
+    "### Experiment 3 — Why we chose these controls\n",
+    "\n",
+    "We considered several possible user-facing controls, such as:\n",
+    "- response style\n",
+    "- verbosity\n",
+    "- strict mode\n",
+    "- row limits\n",
+    "\n",
+    "We selected **Max rows returned** and **SELECT-only** because they were the most useful for our dashboard context.\n",
+    "\n",
+    "### Why these controls fit our dashboard\n",
+    "- our AI tab often works with SQL-like table queries\n",
+    "- row-returning prompts can become too large without a limit\n",
+    "- destructive or non-read-only behavior is not appropriate for this dashboard\n",
+    "- these controls are easy for users to understand and directly improve reliability\n",
+    "\n",
+    "### Trade-off\n",
+    "These controls improve safety and usability, but they are less expressive than style/verbosity controls. We prioritized predictable data access behavior over answer style customization."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21d25e02",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "These experiments support our decision to use **Option A: QueryChat Customization**.\n",
+    "\n",
+    "The final design improves the AI Query tab by:\n",
+    "- giving QueryChat more dataset-specific context\n",
+    "- exposing user-facing controls that affect behavior\n",
+    "- intercepting tool calls to enforce safer and more predictable querying\n",
+    "\n",
+    "Based on these experiments, we concluded that Option A was the best fit for our dashboard because it builds directly on the M3 AI tab and improves both relevance and safety without introducing unnecessary complexity."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3890afba",
+   "metadata": {},
+   "source": [
+    "## Files connected to this experiment\n",
+    "\n",
+    "The final Option A implementation in the dashboard is supported by these files:\n",
+    "\n",
+    "- `src/app.py` - AI tab UI, controls, and QueryChat integration\n",
+    "- `src/utils/querychat_guard.py` - SQL guardrail logic used with `on_tool_request`\n",
+    "- `reports/querychat_data_description.md` - dataset-specific QueryChat context\n",
+    "- `reports/querychat_extra_instructions.md` - extra instructions for dashboard-focused AI behavior\n",
+    "- `reports/m2_spec.md` — specification updates reflecting M4 QueryChat customization decisions\n",
+    "\n",
+    "These files together implement the behaviors discussed in this notebook."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "08e466ab",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
- added a draft QueryChat experiments notebook for M4 Option A
- documented the purpose of the customization work
- recorded current experiment structure and narrative 

Notes
- this notebook is currently a draft and will be finalized after the remaining QueryChat prompt-behavior testing is completed
- the notebook branch is stacked on top of the QueryChat guardrails branch

part of #63 
Closes #81 