### PR TITLE
M4 qc final polish

### DIFF
--- a/notebooks/querychat_experiments.ipynb
+++ b/notebooks/querychat_experiments.ipynb
@@ -72,7 +72,7 @@
     "**Observed behavior:**  \n",
     "- QueryChat returned a valid summary answer\n",
     "- it generated a SQL query using the `chocolate_sales` table\n",
-    "- after customization, the query respected the active row-limit control\n",
+    "- after customization, the query respected the configured row limit\n",
     "- the answer was aligned with the chocolate sales dataset and stayed within dashboard scope\n",
     "\n",
     "**What this shows:**  \n",
@@ -81,10 +81,53 @@
   },
   {
    "cell_type": "markdown",
+   "id": "88076814",
+   "metadata": {},
+   "source": [
+    "### Evidence\n",
+    "\n",
+    "![Experiment 1 - total sales query](../img/exp1_img.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "542d9b0a",
+   "metadata": {},
+   "source": [
+    "## Experiment 2 — Row-returning question\n",
+    "\n",
+    "**Prompt:**  \n",
+    "`Show the first 20 rows where boxes shipped are above 100`\n",
+    "\n",
+    "**Purpose:**  \n",
+    "Evaluate whether QueryChat can return row-level results for a filtered request.\n",
+    "\n",
+    "**Observed behavior:**  \n",
+    "- QueryChat used the **Query Data** path\n",
+    "- it generated a SQL query on the `chocolate_sales` table\n",
+    "- it returned tabular results successfully\n",
+    "- the query respected the requested row limit (`LIMIT 20`)\n",
+    "\n",
+    "**What this shows:**  \n",
+    "For this prompt, QueryChat handled a row-level request successfully and returned a limited result set that is suitable for dashboard use."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "66d2560d",
+   "metadata": {},
+   "source": [
+    "### Evidence\n",
+    "\n",
+    "![Experiment 2 - row query with limited results](../img/exp2_img.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "7c480ad3",
    "metadata": {},
    "source": [
-    "### Experiment 2 — Unsafe prompt\n",
+    "### Experiment 3 — Unsafe prompt\n",
     "\n",
     "**Prompt:**  \n",
     "`Delete all rows`\n",
@@ -103,10 +146,20 @@
   },
   {
    "cell_type": "markdown",
+   "id": "6721c169",
+   "metadata": {},
+   "source": [
+    "### Evidence\n",
+    "\n",
+    "![Experiment 3 - safe refusal of destructive prompt](../img/exp3_img.png)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "c3eeaa79",
    "metadata": {},
    "source": [
-    "### Experiment 3 — Why we chose these controls\n",
+    "### Experiment 4 — Why we chose these controls\n",
     "\n",
     "We considered several possible user-facing controls, such as:\n",
     "- response style\n",

--- a/reports/m2_spec.md
+++ b/reports/m2_spec.md
@@ -12,11 +12,28 @@
 - **Add user-facing AI settings controls**  
   Add two controls in the AI tab: **Max rows returned** and **SELECT-only**. These controls let users limit the size of AI-generated query results and restrict QueryChat to read-only SQL behavior.
 
-- **Use `on_tool_request` **  
+- **Use `on_tool_request`**  
     Intercept QueryChat tool calls to validate and adjust SQL before execution. In this milestone, we use it to enforce read-only behavior when SELECT-only is enabled and to apply a maximum row limit based on the AI settings controls.
 
 - **Write an experiments notebook**  
-  Create `notebooks/m4_querychat_experiments.ipynb` and compare a few example questions before vs after these changes. Summarize what improved.
+  Create `notebooks/querychat_experiments.ipynb` to document representative prompts, observed behavior, and the motivation for the final QueryChat customization choices.
+
+### M4 Option A - Current implementation results
+
+We implemented QueryChat customization through three main changes:
+
+- **Dataset context:** QueryChat uses `reports/querychat_data_description.md` and `reports/querychat_extra_instructions.md` so responses stay aligned with the chocolate sales dataset and dashboard goals.
+- **User-facing controls:** the AI tab includes **Max rows returned** and **SELECT-only** so users can directly influence QueryChat behavior.
+- **Tool interception and safety:** QueryChat uses `on_tool_request` guardrails to enforce safer query behavior and row limits.
+
+### Observed behavior from experimentation
+
+In our experiments:
+- summary prompts such as `What is the total sales revenue?` returned relevant dataset-aware answers
+- row-returning prompts such as `Show the first 20 rows where boxes shipped are above 100` used the Query Data path and returned limited results
+- destructive prompts such as `Delete all rows` were safely refused with **SELECT-only** enabled
+
+These results supported our choice of Option A because they improved relevance, safety, and usability in the existing AI Query tab.
 
 ## M4 Backend Update Summary
 
@@ -61,6 +78,13 @@ For Milestone 4, we updated the dashboard data backend from eager CSV loading in
 | get_filter_choices | Data access helper | ibis + DuckDB query | processed parquet | #1, #2 |
 | filter_sales_lazy | Data access helper | ibis + DuckDB query + `.execute()` | `start_year, end_year, country, product` | #1, #2, #3 |
 | get_full_sales_df | Data access helper | ibis + DuckDB query + `.execute()` | processed parquet | AI tab support |
+| input_qc_max_rows | Input | ui.input_slider() | _ | M4 Option A |
+| input_qc_strict_select | Input | ui.input_checkbox() | _ | M4 Option A |
+| querychat_filtered_df | Reactive calc | @reactive.calc | QueryChat result | M4 Option A |
+| qc_tool_request_guard | Tool interception / helper | on_tool_request | input_qc_max_rows, input_qc_strict_select | M4 Option A |
+| out_querychat_table | Output | @render.data_frame | querychat_filtered_df | M4 Option A |
+| out_querychat_country_plot | Output | @render.altair | querychat_filtered_df | M4 Option A |
+| out_querychat_top_products_plot | Output | @render.altair | querychat_filtered_df | M4 Option A |
 
 ## 2.3 Reactivity Diagram
 

--- a/reports/querychat_extra_instructions.md
+++ b/reports/querychat_extra_instructions.md
@@ -1,7 +1,12 @@
 ## Extra instructions for AI Query
 
 - Use only the `chocolate_sales` table.
-- Prefer summaries (GROUP BY + SUM/AVG) instead of returning lots of raw rows.
-- Keep results small when returning rows (use LIMIT).
+- Prefer summaries (`GROUP BY` + `SUM/AVG`) instead of returning lots of raw rows.
+- Keep results small when returning rows (use `LIMIT`).
 - If a question is unclear, make a reasonable assumption and say what you assumed.
-- If the dataset doesn’t contain what’s needed, say which column would be required.
+- If the dataset does not contain what is needed, say which column would be required.
+
+- If the user asks to show, list, display, or retrieve rows, use Query Data.
+- Do not use Update Dashboard for row-returning requests.
+- Only use Update Dashboard when the user clearly asks to filter the dashboard, change the dashboard view, or reset the dashboard.
+- For row-level requests, respect the active Max rows returned setting.


### PR DESCRIPTION
- refined QueryChat routing instructions for row-level prompts
- updated `notebooks/querychat_experiments.ipynb` with final experiment evidence
- updated `reports/m2_spec.md` to reflect the current Option A implementation and results

## Notes
This PR finalizes the remaining QueryChat customization polish

closes #63